### PR TITLE
Extend base class UIBarItem instead of subclass UIBarButtonItem

### DIFF
--- a/Source/GMDIcon.swift
+++ b/Source/GMDIcon.swift
@@ -50,7 +50,7 @@ public extension UILabel {
     }
 }
 
-public extension UIBarButtonItem {
+public extension UIBarItem {
     
     /**
     To set an icon, use i.e. `barName.GMDIcon = GMDType.GMDPublic`


### PR DESCRIPTION
Allows to use this in UITabBarItem :smile:
